### PR TITLE
Improvements: using vim.keymap and apply multiple exit keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ keystack.config({
     -- the options which will be used when no options were given inside the mapping
     default_opts = { silent = true },
     -- the key to exit the "Group" when no exit key is given inside the mapping
-    default_exit_key = "q",
+    default_exit_key = "q", -- You can pass a table instead if you want multiple ways to exit
     -- the mode which will be used when no mode is given inside the mapping 
     default_mode = "n",
 
@@ -30,6 +30,10 @@ keystack.config({
                 -- key = command
                 ["j"] = "<C-D>",
                 ["k"] = "<C-U>",
+		-- or a function 
+		["<Space>"] = function()
+			-- your function here
+		end,
             }
         },
         ...


### PR DESCRIPTION
Hello, your plugin is very cool, I like it.
But i think this is inconvenient and kinda complex
```lua 
['s'] = ':lua require("dap").toggle_breakpoint()<CR>'
``` 
So I replaced `vim.api.nvim_set_keymap` with `vim.keymap.set` and `vim.api.nvim_del_keymap` with `vim.keymap.del` in `functions.lua`

Result:
```lua
['s'] = function()
      require('dap').toggle_breakpoint()
end
```
Also, i changed a little bit about `exit_key`  to make it can map more than one key
Example:
```lua 
exit_key = 'q'
``` 
to
```lua 
exit_key = {'q','<ESC>'}
```
\
What's your idea about this?